### PR TITLE
github causes a redirect issue w/ curl

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,12 +14,12 @@ includes directions (in the comments) for running from Node instead of Rhino.
 
 A quick one-line install on Mac OS and Linux is:
 
-	curl https://raw.github.com/kriszyp/cpm/master/install | sh
+	curl -L https://raw.github.com/kriszyp/cpm/master/install | sh
 
 To install to a different location, you can use CPM_INSTALL_LIB for the directory where
 to put cpm's directory and CPM_INSTALL_BIN for the directory to symlink the cpm script:
 
-    curl https://raw.github.com/kriszyp/cpm/master/install | CPM_INSTALL_LIB=~/lib CPM_INSTALL_BIN=~/bin sh
+    curl -L https://raw.github.com/kriszyp/cpm/master/install | CPM_INSTALL_LIB=~/lib CPM_INSTALL_BIN=~/bin sh
 
 This would install cpm's libraries in "~/lib/cpm" and symlink the cpm script to "~/bin/cpm".
 Make sure that your ~/lib directory exists before doing this.


### PR DESCRIPTION
since github redirects https://raw.github.com/kriszyp/cpm/master/install to https://raw.githubusercontent.com/kriszyp/cpm/master/install the curl based install no longer works.  Added -L to handle redirects.
